### PR TITLE
Android: add Play Core to detect incomplete installs, link to docs.

### DIFF
--- a/android-app-kotlin/build.gradle
+++ b/android-app-kotlin/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 
     debugImplementation "io.objectbox:objectbox-android-objectbrowser:$objectboxVersion"
     releaseImplementation "io.objectbox:objectbox-android:$objectboxVersion"
+
+    // Optional: if you distribute your app as App Bundle, see the App class for details.
+    implementation 'com.google.android.play:core:1.6.1'
 }
 
 // apply the plugin after the dependencies block so it does not automatically add objectbox-android

--- a/android-app-kotlin/src/main/java/io/objectbox/example/kotlin/App.kt
+++ b/android-app-kotlin/src/main/java/io/objectbox/example/kotlin/App.kt
@@ -1,6 +1,7 @@
 package io.objectbox.example.kotlin
 
 import android.app.Application
+import com.google.android.play.core.missingsplits.MissingSplitsManagerFactory
 
 class App : Application() {
 
@@ -9,6 +10,13 @@ class App : Application() {
     }
 
     override fun onCreate() {
+        // Optional: if you distribute your app as App Bundle, provides detection of incomplete
+        // installs due to sideloading and helps users reinstall the app from Google Play.
+        // https://docs.objectbox.io/android/app-bundle-and-split-apk
+        if (MissingSplitsManagerFactory.create(this).disableAppIfMissingRequiredSplits()) {
+            return // Skip app initialization.
+        }
+
         super.onCreate()
         ObjectBox.init(this)
     }

--- a/android-app/build.gradle
+++ b/android-app/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     debugImplementation "io.objectbox:objectbox-android-objectbrowser:$objectboxVersion"
     releaseImplementation "io.objectbox:objectbox-android:$objectboxVersion"
 
+    // Optional: if you distribute your app as App Bundle, see the App class for details.
+    implementation 'com.google.android.play:core:1.6.1'
+
     testImplementation 'junit:junit:4.12'
 }
 

--- a/android-app/src/main/java/io/objectbox/example/App.java
+++ b/android-app/src/main/java/io/objectbox/example/App.java
@@ -2,12 +2,21 @@ package io.objectbox.example;
 
 import android.app.Application;
 
+import com.google.android.play.core.missingsplits.MissingSplitsManagerFactory;
+
 public class App extends Application {
 
     public static final String TAG = "ObjectBoxExample";
 
     @Override
     public void onCreate() {
+        // Optional: if you distribute your app as App Bundle, provides detection of incomplete
+        // installs due to sideloading and helps users reinstall the app from Google Play.
+        // https://docs.objectbox.io/android/app-bundle-and-split-apk
+        if (MissingSplitsManagerFactory.create(this).disableAppIfMissingRequiredSplits()) {
+            return; // Skip app initialization.
+        }
+
         super.onCreate();
         ObjectBox.init(this);
     }


### PR DESCRIPTION
If you distribute your app as App Bundle and users sideload your app, they may not install all required split APKs. This may crash the app as the split APK containing the ObjectBox native library might be missing.

Google provides the Play Core library for detection of incomplete installs due to sideloading and helps users reinstall the app from Google Play.

https://docs.objectbox.io/android/app-bundle-and-split-apk